### PR TITLE
fix multi db connection problem

### DIFF
--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -39,7 +39,7 @@ class ChecksumTestFixture extends TestFixture
         }
 
         $result = parent::insert($db);
-        static::$_tableHashes[$this->table] = $this->_hash($db);
+        static::$_tableHashes[$this->_getTableKey()] = $this->_hash($db);
         return $result;
     }
 
@@ -85,11 +85,12 @@ class ChecksumTestFixture extends TestFixture
  */
     protected function _tableUnmodified($db)
     {
-        if (empty(static::$_tableHashes[$this->table])) {
+        $tableKey = $this->_getTableKey();
+        if (empty(static::$_tableHashes[$tableKey])) {
             return false;
         }
 
-        if (static::$_tableHashes[$this->table] === $this->_hash($db)) {
+        if (static::$_tableHashes[$tableKey] === $this->_hash($db)) {
             return true;
         }
 
@@ -115,5 +116,15 @@ class ChecksumTestFixture extends TestFixture
         $result = $sth->fetch('assoc');
         $checksum = $result['Checksum'];
         return $checksum;
+    }
+
+/**
+ * Get the key for table hashes
+ *
+ * @return string key for specify connection and table
+ */
+    protected function _getTableKey ()
+    {
+        return $this->connection() . '-' . $this->table;
     }
 }


### PR DESCRIPTION
When same name table exits in multi database, table hashes conflicts and fixture will be broken.
So, with creating `$tableHashes` with `$db->connection` as prefix for this config, the problem will be solved.
```
now: $this->_tableHashes['users']`
will: $this->_tableHashes['test_another-users']
```

----
ex)
```php
// In UsersFixture
class UsersFixture extends ChecksumTestFixture
{
    public $table = 'users';

    public $fields = [
        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
         '_constraints' => [
            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
        ],
    ];

    public $records = [
        [
            'id' => 1,
            'name' => 'foo'
        ]
    ];
}

// In AnotherUsersFixture
class AnotherUsersFixture extends ChecksumTestFixture
{
    public $table = 'users';

    public $connection = 'test_another';

    public $fields = [
        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
         '_constraints' => [
            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
        ],
    ];

    public $records = [
        [
            'id' => 1,
            'name' => 'bar'
        ]
    ];
}
```
```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1' for key 'PRIMARY'.
file: /vendor/composer/cakephp/cakephp/src\/TestSuite\/Fixture\/FixtureManager.php
line: 347
```