### PR TITLE
Update README for class loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ simply use
 
 ``class YourFixture extends ChecksumTestFixture``
 
+and add
+
+``App::uses('ChecksumTestFixture', 'Fixturize.Cake/TestSuite/Fixture');``
+
 Re-run your tests and enjoy the speed!
 
 # Real life improvements


### PR DESCRIPTION
It could be due to our project configuration, but I needed to add `App::uses()` to each fixture for class loading to work in Cake 2.10.x projects.