### PR TITLE
Make it possible to use different fixtures for same tables.

### DIFF
--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -39,7 +39,7 @@ class ChecksumTestFixture extends TestFixture
         }
 
         $result = parent::insert($db);
-        static::$_tableHashes[$this->_getTableKey()] = $this->_hash($db);
+        static::$_tableHashes[get_class($this)] = $this->_hash($db);
         return $result;
     }
 
@@ -68,7 +68,7 @@ class ChecksumTestFixture extends TestFixture
  */
     public function drop(ConnectionInterface $db)
     {
-        unset(static::$_tableHashes[$this->table]);
+        unset(static::$_tableHashes[get_class($this)]);
         return parent::drop($db);
     }
 
@@ -85,12 +85,12 @@ class ChecksumTestFixture extends TestFixture
  */
     protected function _tableUnmodified($db)
     {
-        $tableKey = $this->_getTableKey();
-        if (empty(static::$_tableHashes[$tableKey])) {
+        $fixtureKey = get_class($this);
+        if (empty(static::$_tableHashes[$fixtureKey])) {
             return false;
         }
 
-        if (static::$_tableHashes[$tableKey] === $this->_hash($db)) {
+        if (static::$_tableHashes[$fixtureKey] === $this->_hash($db)) {
             return true;
         }
 
@@ -116,15 +116,5 @@ class ChecksumTestFixture extends TestFixture
         $result = $sth->fetch('assoc');
         $checksum = $result['Checksum'];
         return $checksum;
-    }
-
-/**
- * Get the key for table hashes
- *
- * @return string key for specify connection and table
- */
-    protected function _getTableKey ()
-    {
-        return $this->connection() . '-' . $this->table;
     }
 }


### PR DESCRIPTION
I wrote pull request #6 , for different connections.
To make over-head caused by loading fixture less, often we define small fixtures by separating their `$records` .

This pr satisfies the needs by generating `$_tableHashes` by `get_class()` not `db_name & table_name` .

---
ex)
```php
// Fixture A
class UsersFixture extends TestFixture
{
    public $import = ['table' => 'users'];
    public $records = [
        [
          'id' => 1,
          'name' => 'Alfred',
          'role' => 1,
          'created' => '2007-03-18 10:39:23',
          'modified' => '2007-03-18 10:41:31'
        ];
}

// Fixture B
class UsersWithAdminRoleFixture extends TestFixture
{
    public $import = ['table' => 'users'];
    public $records = [
        [
          'id' => 1,
          'name' => 'Alfred',
          'role' => 5,
          'created' => '2007-03-18 10:39:23',
          'modified' => '2007-03-18 10:41:31'
        ];
}
```
```php

class UsersTest extends TestCase
{
    public $fixtures = ['app.Users', 'app.UsersWithAdminRoleFixture'];
    public $autoFixtures = false;

    public function testMyFunction()
    {
        $this->loadFixtures('Users');
    }

    public function testMyAnotherFunction()
    {
        $this->loadFixtures('UsersWithAdminRoleFixture');
    }
}
```