### PR TITLE
Fallback Connection::getDriver() when using CakePHP<3.4

### DIFF
--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -105,7 +105,13 @@ class ChecksumTestFixture extends TestFixture
  */
     protected function _hash(ConnectionInterface $db)
     {
-        $driver = $db->getDriver();
+        if (method_exists($db, 'getDriver')) {
+            $driver = $db->getDriver();
+        } elseif (method_exists($db, 'driver')) {
+            $driver = $db->driver();
+        } else {
+            $driver = null;
+        }
 
         if (!$driver instanceof Mysql) {
             // Have no better idea right now to make it always regenerate the tables

--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -105,13 +105,7 @@ class ChecksumTestFixture extends TestFixture
  */
     protected function _hash(ConnectionInterface $db)
     {
-        if (method_exists($db, 'getDriver')) {
-            $driver = $db->getDriver();
-        } elseif (method_exists($db, 'driver')) {
-            $driver = $db->driver();
-        } else {
-            $driver = null;
-        }
+        $driver = $db->driver();
 
         if (!$driver instanceof Mysql) {
             // Have no better idea right now to make it always regenerate the tables


### PR DESCRIPTION
`Connection::getDriver()` is implemented CakePHP >= 3.4.
In composer.json, this plugin can be used CakePHP >= 3.2, so i changed use the `driver()` method instead.