### PR TITLE
Generate a table hash that take account of the AUTO_INCREMENT changes

### DIFF
--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -115,7 +115,28 @@ class ChecksumTestFixture extends TestFixture
         $sth = $db->execute("CHECKSUM TABLE " . $this->table . ';');
         $result = $sth->fetch('assoc');
         $checksum = $result['Checksum'];
-        return $checksum;
+
+        // get auto increment count
+        $autoIncrement = $this->_getAutoIncrement($db);
+
+        return $checksum . $autoIncrement;
+    }
+
+/**
+ * Get the table auto increment count
+ *
+ * @param ConnectionInterface $db
+ * @return string
+ */
+    protected function _getAutoIncrement(ConnectionInterface $db)
+    {
+        $autoIncrementSth = $db->execute('SELECT `AUTO_INCREMENT` FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=:schema AND TABLE_NAME=:table;', [
+            'schema' => $db->config()['database'],
+            'table' => $this->table,
+        ]);
+        $autoIncrementResult = $autoIncrementSth->fetch('assoc');
+
+        return (string) $autoIncrementResult['AUTO_INCREMENT'];
     }
 
 /**


### PR DESCRIPTION
`CHECKSUM TABLE` calculates a hash value for the current table record.

This hash value does not include the value of AUTO_INCREMENT, it is not possible to track changes when only the value of AUTO_INCREMENT changes.
For example, if you add a record in a test case and delete that record.

If do not check the change of AUTO_INCREMENT, it will be occurred mismatch problem when assert the record id in the test case.