### PR TITLE
Apply speedup to fixtures with no records as well

### DIFF
--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -86,7 +86,7 @@ class ChecksumTestFixture extends TestFixture
     protected function _tableUnmodified($db)
     {
         $tableKey = $this->_getTableKey();
-        if (empty(static::$_tableHashes[$tableKey])) {
+        if (!array_key_exists($this->table, static::$_tableHashes)) {
             return false;
         }
 


### PR DESCRIPTION
When a fixture describes a table but has no records, `$result['Checksum']` returns '0', resulting in the empty check to always return true, even though the table is already loaded. By switching to array_key_exists, this can be solved, and fixtures without records also enjoy the speedup.