### PR TITLE
Fixing of important bug - tableKey

### DIFF
--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -68,7 +68,7 @@ class ChecksumTestFixture extends TestFixture
  */
     public function drop(ConnectionInterface $db)
     {
-        unset(static::$_tableHashes[$this->table]);
+        unset(static::$_tableHashes[$this->_getTableKey()]);
         return parent::drop($db);
     }
 
@@ -86,7 +86,7 @@ class ChecksumTestFixture extends TestFixture
     protected function _tableUnmodified($db)
     {
         $tableKey = $this->_getTableKey();
-        if (!array_key_exists($this->table, static::$_tableHashes)) {
+        if (!array_key_exists($tableKey, static::$_tableHashes)) {
             return false;
         }
 


### PR DESCRIPTION
ChecksumTestFixture is using _getTableKey() (connection and table name) as key of $_tableHashes in insert(), but when validate modifications, it checks for just table name, which causes incorrect response of _tableUnmodified(), and creating fixtures over again and again.

Big thanks to my colleague @sukihub for finding this bug.

Fixes #13 