### PR TITLE
[2.x] Always return string from ChecksumTestFixture::_hash

### DIFF
--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -114,11 +114,11 @@ class ChecksumTestFixture extends TestFixture
         if ($driver instanceof Mysql) {
             $sth = $db->execute('CHECKSUM TABLE `' . $this->table . '`');
 
-            return $sth->fetchColumn(1);
+            return (string)$sth->fetchColumn(1);
         }
 
         // Have no better idea right now to make it always regenerate the tables
-        return microtime();
+        return microtime(false);
     }
 
     /**


### PR DESCRIPTION
With PHP 8.2 & CakePHP 4.4.x, this lead to ``TypeError : FriendsOfCake\Fixturize\TestSuite\Fixture\ChecksumTestFixture::_hash(): Return value must be of type string, int returned`` when using MySQL as database source.