### PR TITLE
[3.x] feature: TableKey takes into account the class name

### DIFF
--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -114,7 +114,12 @@ class ChecksumTestFixture extends TestFixture
     /**
      * Get the key for table hashes
      *
-     * @return string key for specify connection and table
+     * The key contains:
+     * - The table name
+     * - The connection name to prevent collisions across connections
+     * - The fixture class name to prevent collisions when loading multiple fixtures for the same table throughout a test run
+     *
+     * @return string Key based on connection, table and fixture class names
      */
     protected function _getTableKey(): string
     {

--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -118,6 +118,6 @@ class ChecksumTestFixture extends TestFixture
      */
     protected function _getTableKey(): string
     {
-        return $this->connection() . '-' . $this->table;
+        return $this->connection() . '-' . $this->table . '-' . static::class;
     }
 }


### PR DESCRIPTION
We have the problem that you cannot load 2 fixtures for one table one after the other. For example:

- we load a fixture with 2 rows (Students\UsersFixture),
- the table with 2 rows has not been changed,
- we load a fixture for the same table but with 5 rows (Teachers\UsersFixture).

The last fixture is not applied because the hash was not changed. And the plugin only checks the hash of the table by `connection` and `table name`. The plugin does not take into account the class name of fixtures.