### PR TITLE
[1.x] feat: TableKey takes into account the class name

### DIFF
--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -125,6 +125,6 @@ class ChecksumTestFixture extends TestFixture
  */
     protected function _getTableKey ()
     {
-        return $this->connection() . '-' . $this->table;
+        return $this->connection() . '-' . $this->table . '-' . static::class;
     }
 }

--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -121,6 +121,11 @@ class ChecksumTestFixture extends TestFixture
 /**
  * Get the key for table hashes
  *
+ * The key contains:
+ * - The table name
+ * - The connection name to prevent collisions across connections
+ * - The fixture class name to prevent collisions when loading multiple fixtures for the same table throughout a test run
+ *
  * @return string key based on connection, table and fixture's class
  */
     protected function _getTableKey()

--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -121,9 +121,9 @@ class ChecksumTestFixture extends TestFixture
 /**
  * Get the key for table hashes
  *
- * @return string key for specify connection and table
+ * @return string key based on connection, table and fixture's class
  */
-    protected function _getTableKey ()
+    protected function _getTableKey()
     {
         return $this->connection() . '-' . $this->table . '-' . static::class;
     }


### PR DESCRIPTION
Same as https://github.com/FriendsOfCake/fixturize/pull/28, but for 1.x version.

--

We have the problem that you cannot load 2 fixtures for one table one after the other. For example:

- we load a fixture with 2 rows (Students\UsersFixture),
- the table with 2 rows has not been changed,
- we load a fixture for the same table but with 5 rows (Teachers\UsersFixture).

The last fixture is not applied because the hash was not changed. And the plugin only checks the hash of the table by connection and table name. The plugin does not take into account the class name of fixtures.