### PR TITLE
[2.x] Take fixture name into account for table key hash

### DIFF
--- a/src/TestSuite/Fixture/ChecksumTestFixture.php
+++ b/src/TestSuite/Fixture/ChecksumTestFixture.php
@@ -124,10 +124,15 @@ class ChecksumTestFixture extends TestFixture
     /**
      * Get the key for table hashes
      *
-     * @return string key for specify connection and table
+     * The key contains:
+     * - The table name
+     * - The connection name to prevent collisions across connections
+     * - The fixture class name to prevent collisions when loading multiple fixtures for the same table throughout a test run
+     *
+     * @return string Key based on connection, table and fixture class names
      */
     protected function _getTableKey(): string
     {
-        return $this->connection() . '-' . $this->table;
+        return $this->connection() . '-' . $this->table . '-' . static::class;
     }
 }


### PR DESCRIPTION
Same as @krugerman007  #29 but for version 2.x

Successfully tested on an application with 1400+ tests that previously already used the fixturize plugin.